### PR TITLE
Fix for https://github.com/CradlePHP/Cradle/issues/35

### DIFF
--- a/.cradle.php
+++ b/.cradle.php
@@ -26,109 +26,42 @@ $this->addLogger(function($message, $request, $response) {
 
     $config = $this->package('global')->config('settings');
 
-    $meta = [];
     if (isset($config['history']['file']) && $config['history']['file']) {
-        //To Enable
-        //Insert a new settings for history
-        // Ex: 'history' => [
-        //      'file' => true,
-        //      'path' => 'some/path/under/config'
-        //      ];
-        // Note: Make sure folder permission is 777 of the folders
 
         //generate uniq file name
         $filename = strtotime(date('Y-m-d h:i:s')) + rand();
 
-        //change if history path is empty
+        // force it, if history path is empty
         if (empty($config['history']['path'])) {
             $config['history']['path'] = 'log';
         }
 
-        $path = $this->package('global')->path('config') . '/' . $config['history']['path'];
+        $path = $this->package('global')->path('root') . '/' . $config['history']['path'];
 
-        //if not existing create the folder
-        if (!is_dir($path)) {
-            mkdir($path, 0777);
+        // we are already expecting a log/ during creation of project
+        // if directory is writable
+        if (!is_writable($path)) {
+            chmod($path, 0777); // make it writable
         }
 
-        $meta = [
+        // get request and response as content
+        $content = [
             'request' => $request->get(),
             'response' => $response->get(),
         ];
 
+        // as the name says, put contents in a file
         file_put_contents(
-            $path . '/' . $filename . '.json',
-            json_encode($meta)
+            $filename . '.json',
+            json_encode($content)
         );
 
-        //set the new meta
-        $meta = [
-            'log_file' => sprintf('%s/%s.json', $config['history']['path'], $filename)
-        ];
-    }
-
-    //if history setting is not set (default)
-    if (!isset($meta['log_file'])) {
-        //get meta
-        $data['results'] = $response->hasResults() ? $response->getResults() : '';
-        $data['stage'] = $request->hasStage() ? $request->getStage() : '';
-        $data['post'] = $request->hasPost() ? $request->getPost() : '';
-        $body = !empty($request->getBody()) ? $request->getBody(): '';
-
-        if (strlen($body) > 300) {
-            $body = '< DATA TOO LONG >';
-        }
-
-        //case for long string and data
-        foreach ($data as $keyword => $result) {
-            if (is_array($result)) {
-                foreach ($result as $key => $row) {
-                    if (is_array($row)) {
-                        if (count($row) > 100) {
-                            $data[$keyword][$key] = '< DATA TOO LONG >';
-                            continue;
-                        }
-
-                        foreach ($row as $id => $value) {
-                            if (is_array($value)) {
-                                $value = json_encode($value);
-                            }
-
-                            if (strlen($value) > 300) {
-                                $data[$keyword][$key][$id] = '< DATA TOO LONG >';
-                            }
-                        }
-
-                        continue;
-                    }
-
-                    if (strlen($row) > 300) {
-                        $data[$keyword][$key] = '< DATA TOO LONG >';
-                    }
-                }
-
-                continue;
-            }
-
-            if (strlen($result) > 300) {
-                $data[$keyword] = '< DATA TOO LONG >';
-            }
-        }
-
-        //then reset
-        $request->setStage($data['stage']);
-        $request->setPost($data['post']);
-        $request->setBody($body);
-        $response->setError(false)->setResults($data['results']);
-
-        $meta = [
-            'request' => $request->get(),
-            'response' => $response->get(),
-        ];
+        // sample expected: 1234567890.json
+        $completeFilename = sprintf('%s.json', $filename);
     }
 
     //record logs
-    $logRequest->setStage('history_meta', $meta);
+    $logRequest->setStage('history_meta', $completeFilename);
     $this->trigger('history-create', $logRequest, $logResponse);
 });
 

--- a/package/schema/history.php
+++ b/package/schema/history.php
@@ -91,10 +91,10 @@ return [
         ],
         [
             'disable' => '1',
-            'label' => 'Meta',
-            'name' => 'meta',
+            'label' => 'Path',
+            'name' => 'path',
             'field' => [
-                'type' => 'meta',
+                'type' => 'text',
             ],
             'list' => [
                 'format' => 'hide',


### PR DESCRIPTION
In history table (history_path column), the contents should only have the filename (example: somefile.json) instead of the file path location (/some/path/file.json)